### PR TITLE
Add AppVeyor CI configuration

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,9 @@
+version: 6.9.{build}
+image: Visual Studio 2015
+build_script:
+- cmd: >-
+    dotnet restore -v Warning
+
+    dotnet pack .\Source\MySql.Data -o .\artifacts\MySql.Data -c Release
+artifacts:
+- path: 'artifacts\**\*.nupkg'


### PR DESCRIPTION
Adds an AppVeyor configuration file to build and package MySql.Data. All you need to do is create an AppVeyor account (or use your existing one) and add a project for this repo. You also probably need to add AppVeyor as an integration if its not automatic.

If you want it to automatically deploy to NuGet, you can add the following to the config.

``` yml
deploy:
  provider: NuGet
  api_key:
    secure: aE6G5fDE3fFgMOis/rnef8IdMj16aR57tn7wxh3XenV0rEOI4YqJdNQV9lKV+s07
  artifact: /.*\.nupkg/
  on:
    branch: master
    appveyor_repo_tag: true
```

where secure is your NuGet key encrypted using your AppVeyor account and branch being your deploy branch rather than develop branch.
