### PR TITLE
Add SecuritySafeCritical attribute to CreateSocketStream

### DIFF
--- a/Source/MySql.Data/common/MyNetworkStream.cs
+++ b/Source/MySql.Data/common/MyNetworkStream.cs
@@ -26,11 +26,12 @@ using System.IO;
 using System.Net;
 using System.Net.Sockets;
 using System.Reflection;
+using System.Security;
 using System.Threading.Tasks;
 
 namespace MySql.Data.Common
-{
-  internal class MyNetworkStream : NetworkStream
+{    
+    internal class MyNetworkStream : NetworkStream
   {
     /// <summary>
     /// Wrapper around NetworkStream.
@@ -256,7 +257,7 @@ namespace MySql.Data.Common
       return ep;
     }
 #endif
-
+    [SecuritySafeCritical]
     private static MyNetworkStream CreateSocketStream(MySqlConnectionStringBuilder settings, IPAddress ip, bool unix)
     {
       EndPoint endPoint;

--- a/Source/MySql.Data/project.json
+++ b/Source/MySql.Data/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "6.9.809",
+  "version": "6.9.810",
   "description": "MySQL client library targeting netstandard 1.3",
   "authors": [ "Oracle", "SapientGuardian", "ebyte23" ],
   "buildOptions": {


### PR DESCRIPTION
Fixes #11. The base mysql library uses the old security level 1, which allows any code to call any other code. Netstandard (and more specifically, coreclr) only supports the more strict level 2. This requires security sensitive code to be annotated to allow it to be called by security transparent (unannotated) code.
