### PR TITLE
Remove async and add .wait() in Open() so exceptions can be caught

### DIFF
--- a/Source/MySql.Data/NativeDriver.cs
+++ b/Source/MySql.Data/NativeDriver.cs
@@ -192,16 +192,16 @@ namespace MySql.Data.MySqlClient
       stream.Encoding = Encoding;
     }
 
-    public async void Open()
+    public void Open()
     {
       // connect to one of our specified hosts
       try
       {
-#if NETSTANDARD1_3
-            baseStream = StreamCreator.GetStream(Settings).Result;
-#else
-            baseStream = await StreamCreator.GetStream(Settings);
-#endif
+
+        var streamTask = StreamCreator.GetStream(Settings);
+        streamTask.Wait();
+        baseStream = streamTask.Result;
+
 #if !CF && !RT && !NETSTANDARD1_3
          if (Settings.IncludeSecurityAsserts)
             MySqlSecurityPermission.CreatePermissionSet(false).Assert();

--- a/Source/MySql.Data/project.json
+++ b/Source/MySql.Data/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "6.9.810",
+  "version": "6.9.811",
   "description": "MySQL client library targeting netstandard 1.3",
   "authors": [ "Oracle", "SapientGuardian", "ebyte23" ],
   "buildOptions": {


### PR DESCRIPTION
The async void signature of the Open method made it impossible for callers to catch exceptions in the correct context. This PR removes async and adds .wait() in Open() so exceptions can be caught. It also simplifies our ifdefs.
