### PR TITLE
Fixed MySqlDataReader not disposed by EntityFrameworkCore

### DIFF
--- a/Source/MySql.Data/datareader.cs
+++ b/Source/MySql.Data/datareader.cs
@@ -37,7 +37,7 @@ using System.Threading;
 namespace MySql.Data.MySqlClient
 {
   /// <include file='docs/MySqlDataReader.xml' path='docs/ClassSummary/*'/>
-  public sealed partial class MySqlDataReader : IDisposable
+  public sealed partial class MySqlDataReader : DbDataReader
   {
     // The DataReader should always be open when returned to the user.
     private bool isOpen = true;
@@ -1035,14 +1035,10 @@ namespace MySql.Data.MySqlClient
       throw ex;
     }
 
-    public new void Dispose()
+    protected override void Dispose(bool disposing)
     {
-      Dispose(true);
-      GC.SuppressFinalize(this);
-    }
+      base.Dispose(disposing);
 
-    internal new void Dispose(bool disposing)
-    {
       if (disposing)
       {
         Close();


### PR DESCRIPTION
EntityFrameworkCore wasn't disposing MySqlDataReader because MySqlDataReader doesn't inherit from DbDataReader.
Here is the exception thrown:

> Microsoft.EntityFrameworkCore.DbContext:Error: An exception occurred in the database while saving changes.
> MySql.Data.MySqlClient.MySqlException: There is already an open DataReader associated with this Connection which must be closed first.
>    at MySql.Data.MySqlClient.ExceptionInterceptor.Throw(Exception exception)
>    at MySql.Data.MySqlClient.MySqlCommand.CheckState()
>    at MySql.Data.MySqlClient.MySqlCommand.ExecuteReader(CommandBehavior behavior)
>    at MySql.Data.MySqlClient.MySqlCommand.ExecuteNonQuery()
>    at MySql.Data.MySqlClient.MySqlTransaction.Commit()
>    at Microsoft.EntityFrameworkCore.Storage.RelationalTransaction.Commit()
>    at Microsoft.EntityFrameworkCore.Update.Internal.BatchExecutor.<ExecuteAsync>d__1.MoveNext()

This commit fixes the issue.
