### PR TITLE
Remove IFDEF for MySqlConnectionStringBuilder

### DIFF
--- a/Source/MySql.Data/Driver.cs
+++ b/Source/MySql.Data/Driver.cs
@@ -193,7 +193,7 @@ namespace MySql.Data.MySqlClient
     public static Driver Create(MySqlConnectionStringBuilder settings)
     {
       Driver d = null;
-#if !CF && !RT && !NETSTANDARD1_3
+#if !CF && !RT
       try
       {
         if (MySqlTrace.QueryAnalysisEnabled || settings.Logging || settings.UseUsageAdvisor)


### PR DESCRIPTION
Allow .netstandard to utilise the MySqlConnectionStringBuilder feature, generally used in ORM DatabaseFactories.
Found when using NPoco DatabaseFactory
