### PR TITLE
fixing encoding for utf-8 not english

### DIFF
--- a/Source/MySql.Data/Field.cs
+++ b/Source/MySql.Data/Field.cs
@@ -85,6 +85,7 @@ namespace MySql.Data.MySqlClient
       connVersion = driver.Version;
       maxLength = 1;
       binaryOk = true;
+      Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
     }
 
     #region Properties

--- a/Source/MySql.Data/project.json
+++ b/Source/MySql.Data/project.json
@@ -53,7 +53,8 @@
     "System.Reflection.TypeExtensions": "4.1.0",
     "System.Security.Cryptography.X509Certificates": "4.1.0",
     "System.Net.Security": "4.0.0",
-    "System.Runtime.InteropServices.RuntimeInformation": "4.0.0"
+    "System.Runtime.InteropServices.RuntimeInformation": "4.0.0",
+    "System.Text.Encoding.CodePages": "4.3.0"
   },
   "frameworks": {
     "netstandard1.3": {


### PR DESCRIPTION
Likely correction for: 

https://github.com/SapientGuardian/SapientGuardian.EntityFrameworkCore.MySql/issues/48


