### PR TITLE
Unbreak consumption in net461

### DIFF
--- a/Source/MySql.Data/Field.cs
+++ b/Source/MySql.Data/Field.cs
@@ -28,6 +28,7 @@ using System.Text.RegularExpressions;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Security;
 
 namespace MySql.Data.MySqlClient
 {
@@ -77,9 +78,10 @@ namespace MySql.Data.MySqlClient
     protected bool binaryOk;
     protected List<Type> typeConversions = new List<Type>();
 
-    #endregion
+        #endregion
 
-    public MySqlField(Driver driver)
+        [SecuritySafeCritical]
+        public MySqlField(Driver driver)
     {
       this.driver = driver;
       connVersion = driver.Version;

--- a/Source/MySql.Data/project.json
+++ b/Source/MySql.Data/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "6.9.815",
+  "version": "6.9.816",
   "description": "MySQL client library targeting netstandard 1.3",
   "authors": [ "Oracle", "SapientGuardian", "ebyte23" ],
   "buildOptions": {


### PR DESCRIPTION
This MR adds [SecuritySafeCritical] attribute to MySqlField ctor to unbreak consumption in net461. See #33 for context.